### PR TITLE
Filepath corrected

### DIFF
--- a/Netatmo/module.php
+++ b/Netatmo/module.php
@@ -1,6 +1,6 @@
 <?
 define('__ROOT__', dirname(dirname(__FILE__)));
-require_once (__ROOT__.'/Netatmo2/src/Netatmo/autoload.php');
+require_once (__ROOT__.'/Netatmo/src/Netatmo/autoload.php');
 
 
     // Klassendefinition


### PR DESCRIPTION
It wasn't possible to use the module because the filepath 'Netatmo2/src/Netatmo/autoload.php' doesn't exist.